### PR TITLE
test: boost: mulitshard_combining_reader_as_mutation_source_test: allow redundant range tombstone changes

### DIFF
--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -607,7 +607,7 @@ future<> evictable_reader_v2::fill_buffer() {
         // First make sure we've made progress w.r.t. _next_position_in_partition.
         // This loop becomes inifinite when next pos is a partition start.
         // In that case progress is guranteed anyway, so skip this loop entirely.
-        while (!_next_position_in_partition.is_partition_start() && next_mf && _tri_cmp(_next_position_in_partition, buffer().back().position()) <= 0) {
+        while (!_next_position_in_partition.is_partition_start() && next_mf && _tri_cmp(buffer().back().position(), _next_position_in_partition) <= 0) {
             push_mutation_fragment(_reader->pop_mutation_fragment());
             next_mf = co_await _reader->peek();
         }


### PR DESCRIPTION
test_range_tombstones_v2 is too strict for this reader -- it expects a particular sequence of range tombstone changes, but multishard_combining_reader, when tested with a small buffer, generates -- as expected -- additional (redundant) range tombstone change pairs (end+start).

We would rather not modify test_range_tombstones_v2, because catching redundancy is good in general, so to fix this problem, we wrap the tested reader with a filter that removes these redundant range tombstone changes, when they are expected.